### PR TITLE
feat: add auto loading feature from local storage

### DIFF
--- a/dist/canvas/Canvas.d.ts
+++ b/dist/canvas/Canvas.d.ts
@@ -5,6 +5,7 @@ export declare class Canvas {
   private sidebarElement;
   private componentCounters;
   historyManager: HistoryManager;
+  private jsonStorage;
   private static componentFactory;
   constructor();
   getState(): {

--- a/dist/index.js
+++ b/dist/index.js
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
   (_a = document.getElementById('save-btn')) === null || _a === void 0
     ? void 0
     : _a.addEventListener('click', () => {
-        const layoutJSON = canvas.exportLayout();
+        const layoutJSON = canvas.getState();
         jsonStorage.save(layoutJSON);
       });
   (_b = document.getElementById('export-html-btn')) === null || _b === void 0

--- a/dist/utils/iconsConfig.d.ts
+++ b/dist/utils/iconsConfig.d.ts
@@ -1,7 +1,0 @@
-export declare const iconsConfig: {
-  button: string;
-  header: string;
-  image: string;
-  text: string;
-  container: string;
-};

--- a/dist/utils/iconsConfig.js
+++ b/dist/utils/iconsConfig.js
@@ -1,7 +1,0 @@
-export const iconsConfig = {
-  button: '/dist/icons/button.png',
-  header: '/dist/icons/header.png',
-  image: '/dist/icons/image.png',
-  text: 'dist/icons/text.png',
-  container: '/dist/icons/square.png',
-};

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Additional event listeners for exporting or saving
   document.getElementById('save-btn')?.addEventListener('click', () => {
-    const layoutJSON = canvas.exportLayout();
+    const layoutJSON = canvas.getState();
     jsonStorage.save(layoutJSON);
   });
 


### PR DESCRIPTION
## Pull Request Title

Add auto loading feature from local storage

---

## Description

### What does this PR do?

This PR introduces an auto-loading feature that ensures the canvas state is saved and automatically loaded from local storage. This enhancement prevents loss of progress when the user closes the tab or refreshes the page.

### Related Issues

- Closes #2635093820

## Type of Change

- [ ] 🐛 Bug fix
- [x] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

- [x] I have linted my code using `npm run lint`.
- [x] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [x] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

No screenshots

## Additional Context

This feature leverages local storage to enhance the user experience by ensuring that canvas progress is maintained across sessions.
---
### Thank you for your contribution!

We appreciate your efforts in making this project better.