### PR TITLE
feat: add notification and dialog box layout

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4,6 +4,7 @@ import { createSidebar } from './sidebar/CreateSidebar.js';
 import { createNavbar } from './navbar/CreateNavbar.js';
 import { HTMLGenerator } from './services/HTMLGenerator.js';
 import { JSONStorage } from './services/JSONStorage.js';
+import { showDialogBox, showNotification } from './utils/utilityFunctions.js';
 document.addEventListener('DOMContentLoaded', () => {
   var _a, _b, _c, _d, _e, _f, _g, _h;
   const canvas = new Canvas();
@@ -21,22 +22,26 @@ document.addEventListener('DOMContentLoaded', () => {
     ? void 0
     : _a.addEventListener('click', () => {
         const layoutJSON = Canvas.getState();
+        showNotification('Saving progress...');
         jsonStorage.save(layoutJSON);
       });
   (_b = document.getElementById('reset-btn')) === null || _b === void 0
     ? void 0
     : _b.addEventListener('click', () => {
-        // Prompt the user for confirmation
-        const confirmReset = window.confirm(
-          'Are you sure you want to reset the layout?'
+        // Show the dialog with a custom message
+        showDialogBox(
+          'Are you sure you want to reset the layout?', // Message
+          () => {
+            // Action if the user confirms (clicks 'Yes')
+            jsonStorage.remove();
+            Canvas.clearCanvas();
+            showNotification('The saved layout has been successfully reset.');
+          },
+          () => {
+            // Action if the user cancels (clicks 'No')
+            console.log('Layout reset canceled.');
+          }
         );
-        if (confirmReset) {
-          // If confirmed, remove the saved layout from storage
-          jsonStorage.remove();
-          Canvas.clearCanvas();
-          // Show a success message
-          alert('The saved layout has been successfully reset.');
-        }
       });
   (_c = document.getElementById('export-html-btn')) === null || _c === void 0
     ? void 0

--- a/dist/utils/utilityFunctions.d.ts
+++ b/dist/utils/utilityFunctions.d.ts
@@ -1,0 +1,6 @@
+export declare function showNotification(message: string): void;
+export declare function showDialogBox(
+  message: string,
+  onConfirm: () => void,
+  onCancel: () => void
+): void;

--- a/dist/utils/utilityFunctions.js
+++ b/dist/utils/utilityFunctions.js
@@ -1,0 +1,48 @@
+//Function for toggling notification
+export function showNotification(message) {
+  const notification = document.getElementById('notification');
+  if (notification) {
+    notification.innerHTML = message;
+    notification.classList.add('visible');
+    notification.classList.remove('hidden');
+    // Hide the notification after 2 seconds
+    setTimeout(() => {
+      notification.classList.remove('visible');
+      notification.classList.add('hidden');
+    }, 2000);
+  }
+}
+//Function for handling dialog box, where confirmation and cancellation functions are passed as parameters
+export function showDialogBox(message, onConfirm, onCancel) {
+  // Get the dialog and buttons from the DOM
+  const dialog = document.getElementById('dialog');
+  const yesButton = document.getElementById('dialog-yes');
+  const noButton = document.getElementById('dialog-no');
+  // Set the dialog message
+  const messageElement = document.getElementById('dialog-message');
+  if (messageElement) {
+    messageElement.innerHTML = message;
+  }
+  // Show the dialog by removing the 'hidden' class
+  dialog === null || dialog === void 0
+    ? void 0
+    : dialog.classList.remove('hidden');
+  // Handle the 'Yes' button click
+  yesButton === null || yesButton === void 0
+    ? void 0
+    : yesButton.addEventListener('click', () => {
+        onConfirm(); // Execute the onConfirm function
+        dialog === null || dialog === void 0
+          ? void 0
+          : dialog.classList.add('hidden'); // Hide the dialog after action
+      });
+  // Handle the 'No' button click
+  noButton === null || noButton === void 0
+    ? void 0
+    : noButton.addEventListener('click', () => {
+        onCancel(); // Execute the onCancel function
+        dialog === null || dialog === void 0
+          ? void 0
+          : dialog.classList.add('hidden'); // Hide the dialog after action
+      });
+}

--- a/index.html
+++ b/index.html
@@ -14,6 +14,16 @@
     <div id="app">
         <div id="sidebar"></div>
       <div id="canvas" class="canvas"></div>
+      <!-- Notification for saving -->
+      <div id="notification" class="notification hidden"></div>
+      <!-- Dialog for reset  -->
+      <div id="dialog" class="dialog hidden">
+        <div class="dialog-content">
+          <p id="dialog-message"></p>
+          <button id="dialog-yes" class="dialog-btn">Yes</button>
+          <button id="dialog-no" class="dialog-btn">No</button>
+        </div>
+      </div>
     </div>
 
     <!-- Bundle JavaScript -->

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { createSidebar } from './sidebar/CreateSidebar';
 import { createNavbar } from './navbar/CreateNavbar';
 import { HTMLGenerator } from './services/HTMLGenerator';
 import { JSONStorage } from './services/JSONStorage';
+import { showDialogBox, showNotification } from './utils/utilityFunctions';
 
 document.addEventListener('DOMContentLoaded', () => {
   const canvas = new Canvas();
@@ -20,21 +21,24 @@ document.addEventListener('DOMContentLoaded', () => {
   // Additional event listeners for exporting or saving
   document.getElementById('save-btn')?.addEventListener('click', () => {
     const layoutJSON = Canvas.getState();
+    showNotification('Saving progress...');
     jsonStorage.save(layoutJSON);
   });
   document.getElementById('reset-btn')?.addEventListener('click', () => {
-    // Prompt the user for confirmation
-    const confirmReset = window.confirm(
-      'Are you sure you want to reset the layout?'
+    // Show the dialog with a custom message
+    showDialogBox(
+      'Are you sure you want to reset the layout?', // Message
+      () => {
+        // Action if the user confirms (clicks 'Yes')
+        jsonStorage.remove();
+        Canvas.clearCanvas();
+        showNotification('The saved layout has been successfully reset.');
+      },
+      () => {
+        // Action if the user cancels (clicks 'No')
+        console.log('Layout reset canceled.');
+      }
     );
-
-    if (confirmReset) {
-      // If confirmed, remove the saved layout from storage
-      jsonStorage.remove();
-      Canvas.clearCanvas();
-      // Show a success message
-      alert('The saved layout has been successfully reset.');
-    }
   });
 
   document.getElementById('export-html-btn')?.addEventListener('click', () => {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -278,3 +278,70 @@ html {
   opacity: 1;
   background-color: rgba(0, 0, 0, 0.253);
 }
+
+/* Notification styling */
+.notification {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background-color: #4caf50; /* Green */
+  color: white;
+  padding: 10px 20px;
+  border-radius: 5px;
+  font-size: 16px;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+}
+
+.notification.visible {
+  opacity: 1;
+}
+
+.notification.hidden {
+  opacity: 0;
+}
+
+/* Styling for dialog box */
+.dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.dialog.hidden {
+  display: none;
+}
+
+.dialog-content {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+  width: 300px;
+}
+
+.dialog-btn {
+  margin: 10px;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#dialog-yes {
+  background-color: #e74c3c;
+  color: white;
+}
+
+#dialog-no {
+  background-color: #95a5a6;
+  color: white;
+}

--- a/src/utils/utilityFunctions.ts
+++ b/src/utils/utilityFunctions.ts
@@ -1,0 +1,48 @@
+//Function for toggling notification
+export function showNotification(message: string) {
+  const notification = document.getElementById('notification');
+  if (notification) {
+    notification.innerHTML = message;
+    notification.classList.add('visible');
+    notification.classList.remove('hidden');
+
+    // Hide the notification after 2 seconds
+    setTimeout(() => {
+      notification.classList.remove('visible');
+      notification.classList.add('hidden');
+    }, 2000);
+  }
+}
+
+//Function for handling dialog box, where confirmation and cancellation functions are passed as parameters
+export function showDialogBox(
+  message: string,
+  onConfirm: () => void,
+  onCancel: () => void
+) {
+  // Get the dialog and buttons from the DOM
+  const dialog = document.getElementById('dialog');
+  const yesButton = document.getElementById('dialog-yes');
+  const noButton = document.getElementById('dialog-no');
+
+  // Set the dialog message
+  const messageElement = document.getElementById('dialog-message');
+  if (messageElement) {
+    messageElement.innerHTML = message;
+  }
+
+  // Show the dialog by removing the 'hidden' class
+  dialog?.classList.remove('hidden');
+
+  // Handle the 'Yes' button click
+  yesButton?.addEventListener('click', () => {
+    onConfirm(); // Execute the onConfirm function
+    dialog?.classList.add('hidden'); // Hide the dialog after action
+  });
+
+  // Handle the 'No' button click
+  noButton?.addEventListener('click', () => {
+    onCancel(); // Execute the onCancel function
+    dialog?.classList.add('hidden'); // Hide the dialog after action
+  });
+}


### PR DESCRIPTION
## Pull Request Title

**feat: add notification and dialog box layout**

---

## Description

### What does this PR do?

This PR introduces a notification and dialog box layout for the following features:
1. **Notification**: Displays a message when the layout is saved to local storage.
2. **Dialog Box**: A confirmation dialog appears when resetting the layout, ensuring the user confirms the reset action.

### Related Issues

- Closes #2635093820

## Type of Change

- [ ] 🐛 Bug fix
- [x] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

- [x] I have linted my code using `npm run lint`.
- [x] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [x] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).



## Additional Context

_Include any other context, references, or information that may be useful for the reviewers._

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._
