### PR TITLE
fix: fix image upload and re-rendering issue

### DIFF
--- a/dist/canvas/Canvas.d.ts
+++ b/dist/canvas/Canvas.d.ts
@@ -36,6 +36,7 @@ export declare class Canvas {
       height: string;
     };
     classes: string[];
+    imageSrc: string | null;
   }[];
   /**
    * Restores the canvas to a previous state.

--- a/dist/canvas/Canvas.js
+++ b/dist/canvas/Canvas.js
@@ -67,6 +67,10 @@ export class Canvas {
       const baseType = component.classList[0]
         .split(/\d/)[0]
         .replace('-component', '');
+      // Capture the image src for image components
+      const imageSrc = component.querySelector('img')
+        ? component.querySelector('img').src
+        : null;
       return {
         type: baseType,
         content: component.innerHTML,
@@ -74,12 +78,10 @@ export class Canvas {
           x: component.offsetLeft,
           y: component.offsetTop,
         },
-        // Capture dimensions explicitly
         dimensions: {
           width: component.offsetWidth,
           height: component.offsetHeight,
         },
-        // Capture all relevant styles to preserve appearance
         style: {
           position: component.style.position,
           left: component.style.left,
@@ -88,6 +90,7 @@ export class Canvas {
           height: component.style.height,
         },
         classes: Array.from(component.classList),
+        imageSrc: imageSrc, // Store the image source if it's an image component
       };
     });
   }
@@ -120,6 +123,9 @@ export class Canvas {
         // If it's a container, restore resizer functionality
         if (component.classList.contains('container-component')) {
           ContainerComponent.restoreResizer(component);
+        }
+        if (componentData.type === 'image') {
+          ImageComponent.restoreImageUpload(component, componentData.imageSrc); // Restore image state
         }
         // Append to the canvas and add to the components array
         Canvas.canvasElement.appendChild(component);

--- a/dist/components/ImageComponent.d.ts
+++ b/dist/components/ImageComponent.d.ts
@@ -1,4 +1,5 @@
 export declare class ImageComponent {
   create(src?: string): HTMLElement;
-  private handleFileChange;
+  static handleFileChange(event: Event, container: HTMLElement): void;
+  static restoreImageUpload(component: HTMLElement, src: string): void;
 }

--- a/dist/components/ImageComponent.js
+++ b/dist/components/ImageComponent.js
@@ -4,16 +4,14 @@ export class ImageComponent {
     const container = document.createElement('div');
     container.classList.add('image-component');
     // Generate and assign a unique ID to the container
-    const uniqueContainerId = `image-container-${Date.now()}-${Math.random()
-      .toString(36)
-      .substring(2, 10)}`;
+    const uniqueContainerId = `image-container-${Date.now()}-${Math.random().toString(36).substring(2, 10)}`;
     // Create the file input for uploading an image (hidden by default)
     const fileInput = document.createElement('input');
     fileInput.type = 'file';
     fileInput.accept = 'image/*';
     fileInput.style.display = 'none'; // Hide the file input
     fileInput.addEventListener('change', event =>
-      this.handleFileChange(event, container)
+      ImageComponent.handleFileChange(event, container)
     );
     // Create the pencil icon button (visible on hover)
     const pencilButton = document.createElement('button');
@@ -35,17 +33,39 @@ export class ImageComponent {
     container.appendChild(element);
     return container;
   }
-  handleFileChange(event, container) {
+  static handleFileChange(event, container) {
     const fileInput = event.target;
     const file = fileInput.files ? fileInput.files[0] : null;
     if (file) {
-      // Create an object URL for the uploaded file
-      const objectURL = URL.createObjectURL(file);
-      // Find the image element by querying the container
-      const imageElement = container.querySelector('img');
-      if (imageElement) {
-        imageElement.src = objectURL; // Update the image source to the uploaded image
-      }
+      const reader = new FileReader();
+      // Convert file to Base64 string
+      reader.onload = function () {
+        const base64String = reader.result;
+        // Find the image element and set its src to the Base64 string
+        const imageElement = container.querySelector('img');
+        if (imageElement) {
+          imageElement.src = base64String;
+        }
+      };
+      reader.readAsDataURL(file); // Convert image to Base64
     }
+  }
+  // Method to restore the image upload functionality after state is restored
+  static restoreImageUpload(component, src) {
+    // Recreate the file input for uploading an image (hidden by default)
+    const fileInput = component.querySelector('input[type="file"]');
+    fileInput.addEventListener('change', event =>
+      this.handleFileChange(event, component)
+    );
+    // Recreate the pencil icon button
+    const pencilButton = component.querySelector('.upload-btn');
+    pencilButton.addEventListener('click', () => fileInput.click()); // Trigger file input on click
+    // Recreate the image element
+    const imageElement = component.querySelector('img');
+    imageElement.src = src; // Restore the image source
+    // Reapply the image element styles if necessary
+    imageElement.style.width = '100%';
+    imageElement.style.height = '100%';
+    imageElement.style.objectFit = 'contain';
   }
 }

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -94,6 +94,12 @@ export class Canvas {
       const baseType = component.classList[0]
         .split(/\d/)[0]
         .replace('-component', '');
+
+      // Capture the image src for image components
+      const imageSrc = component.querySelector('img')
+        ? (component.querySelector('img') as HTMLImageElement).src
+        : null;
+
       return {
         type: baseType,
         content: component.innerHTML,
@@ -101,12 +107,10 @@ export class Canvas {
           x: component.offsetLeft,
           y: component.offsetTop,
         },
-        // Capture dimensions explicitly
         dimensions: {
           width: component.offsetWidth,
           height: component.offsetHeight,
         },
-        // Capture all relevant styles to preserve appearance
         style: {
           position: component.style.position,
           left: component.style.left,
@@ -115,6 +119,7 @@ export class Canvas {
           height: component.style.height,
         },
         classes: Array.from(component.classList),
+        imageSrc: imageSrc, // Store the image source if it's an image component
       };
     });
   }
@@ -152,6 +157,9 @@ export class Canvas {
         // If it's a container, restore resizer functionality
         if (component.classList.contains('container-component')) {
           ContainerComponent.restoreResizer(component);
+        }
+        if (componentData.type === 'image') {
+          ImageComponent.restoreImageUpload(component, componentData.imageSrc); // Restore image state
         }
 
         // Append to the canvas and add to the components array

--- a/src/components/ImageComponent.ts
+++ b/src/components/ImageComponent.ts
@@ -4,16 +4,15 @@ export class ImageComponent {
     const container = document.createElement('div');
     container.classList.add('image-component');
     // Generate and assign a unique ID to the container
-    const uniqueContainerId = `image-container-${Date.now()}-${Math.random()
-      .toString(36)
-      .substring(2, 10)}`;
+    const uniqueContainerId = `image-container-${Date.now()}-${Math.random().toString(36).substring(2, 10)}`;
+
     // Create the file input for uploading an image (hidden by default)
     const fileInput = document.createElement('input');
     fileInput.type = 'file';
     fileInput.accept = 'image/*';
     fileInput.style.display = 'none'; // Hide the file input
     fileInput.addEventListener('change', event =>
-      this.handleFileChange(event, container)
+      ImageComponent.handleFileChange(event, container)
     );
 
     // Create the pencil icon button (visible on hover)
@@ -39,19 +38,49 @@ export class ImageComponent {
     return container;
   }
 
-  private handleFileChange(event: Event, container: HTMLElement): void {
+  static handleFileChange(event: Event, container: HTMLElement): void {
     const fileInput = event.target as HTMLInputElement;
     const file = fileInput.files ? fileInput.files[0] : null;
 
     if (file) {
-      // Create an object URL for the uploaded file
-      const objectURL = URL.createObjectURL(file);
+      const reader = new FileReader();
 
-      // Find the image element by querying the container
-      const imageElement = container.querySelector('img');
-      if (imageElement) {
-        imageElement.src = objectURL; // Update the image source to the uploaded image
-      }
+      // Convert file to Base64 string
+      reader.onload = function () {
+        const base64String = reader.result as string;
+
+        // Find the image element and set its src to the Base64 string
+        const imageElement = container.querySelector('img');
+        if (imageElement) {
+          imageElement.src = base64String;
+        }
+      };
+
+      reader.readAsDataURL(file); // Convert image to Base64
     }
+  }
+
+  // Method to restore the image upload functionality after state is restored
+  static restoreImageUpload(component: HTMLElement, src: string): void {
+    // Recreate the file input for uploading an image (hidden by default)
+    const fileInput = component.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    fileInput.addEventListener('change', event =>
+      this.handleFileChange(event, component)
+    );
+
+    // Recreate the pencil icon button
+    const pencilButton = component.querySelector('.upload-btn') as HTMLElement;
+    pencilButton.addEventListener('click', () => fileInput.click()); // Trigger file input on click
+
+    // Recreate the image element
+    const imageElement = component.querySelector('img') as HTMLImageElement;
+    imageElement.src = src; // Restore the image source
+
+    // Reapply the image element styles if necessary
+    imageElement.style.width = '100%';
+    imageElement.style.height = '100%';
+    imageElement.style.objectFit = 'contain';
   }
 }


### PR DESCRIPTION
## Pull Request Title

**Fix: Image Upload and Re-rendering Issue**

---

## Description

### What does this PR do?

This PR resolves issues with:
1. **Image Upload for Restored State**: Images in a restored state were not being uploaded correctly during restoration.
2. **Image Re-rendering on Page Reload**: Uploaded images were not rendering correctly after a page reload due to missing state linkage.

### Related Issues

- Closes #789 (example issue reference, replace with the actual issue number if applicable)

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.
- [x] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [x] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

_Provide screenshots or GIFs if this PR changes the UI or has visible results._

- Before: Images not uploading correctly or failing to render after page reload.
- After: Images upload successfully and persist across page reloads.

## Additional Context

To fix the issue:
1. **State Restoration for Images**: Added logic to correctly store and restore image paths or data during the restoration process.
2. **Re-rendering Logic**: Ensured the image elements are linked to the restored state and render consistently across page loads.

This fix ensures seamless handling of image uploads and restores the user experience for image components.

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._
