### PR TITLE
fix: fix image re-upload issue inside a restored container

### DIFF
--- a/dist/components/ContainerComponent.js
+++ b/dist/components/ContainerComponent.js
@@ -1,4 +1,5 @@
 import { Canvas } from '../canvas/Canvas.js';
+import { ImageComponent } from './ImageComponent.js';
 export class ContainerComponent {
   constructor() {
     this.MINIMUM_SIZE = 20;
@@ -245,6 +246,7 @@ export class ContainerComponent {
     // Reapply controls to child components inside the container
     const containerChildren = container.querySelectorAll('.editable-component');
     containerChildren.forEach(child => {
+      var _a;
       // Add control buttons and draggable listeners
       Canvas.controlsManager.addControlButtons(child);
       Canvas.addDraggableListeners(child);
@@ -255,6 +257,14 @@ export class ContainerComponent {
       child.addEventListener('mouseleave', event =>
         containerInstance.hideLabel(event, child)
       );
+      // If the child is an image component, restore the image upload feature
+      if (child.classList.contains('image-component')) {
+        const imageSrc =
+          ((_a = child.querySelector('img')) === null || _a === void 0
+            ? void 0
+            : _a.getAttribute('src')) || ''; // Get the saved image source
+        ImageComponent.restoreImageUpload(child, imageSrc);
+      }
       // If the child is itself a container, restore it recursively
       if (child.classList.contains('container-component')) {
         this.restoreContainer(child);

--- a/src/components/ContainerComponent.ts
+++ b/src/components/ContainerComponent.ts
@@ -1,4 +1,5 @@
 import { Canvas } from '../canvas/Canvas';
+import { ImageComponent } from './ImageComponent';
 
 export class ContainerComponent {
   private element: HTMLElement;
@@ -295,6 +296,12 @@ export class ContainerComponent {
       child.addEventListener('mouseleave', (event: MouseEvent) =>
         containerInstance.hideLabel(event, child)
       );
+
+      // If the child is an image component, restore the image upload feature
+      if (child.classList.contains('image-component')) {
+        const imageSrc = child.querySelector('img')?.getAttribute('src') || ''; // Get the saved image source
+        ImageComponent.restoreImageUpload(child, imageSrc);
+      }
 
       // If the child is itself a container, restore it recursively
       if (child.classList.contains('container-component')) {


### PR DESCRIPTION
## Pull Request Title

**Fix: Image Re-upload Issue Inside a Restored Container**

---

## Description

### What does this PR do?

This PR addresses the issue where images could not be re-uploaded inside a restored container. The fix ensures that the image upload functionality works seamlessly for containers in the restored state.

### Related Issues

- Closes #ISSUE_NUMBER (replace with actual issue number if applicable)

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.
- [x] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [x] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

- Before:
  - Re-uploading images inside restored containers was failing.
- After:
  - Image re-upload works as expected inside restored containers.

## Additional Context

The issue was resolved by ensuring that:
1. The image input events were properly reinitialized when a container was restored.
2. Necessary event listeners were correctly reattached to handle re-upload functionality.

This fix enhances the user experience when working with images inside restored containers.

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._
