### PR TITLE
feat: add new feature for controlling undo redo by shortcut keys

### DIFF
--- a/dist/components/ContainerComponent.js
+++ b/dist/components/ContainerComponent.js
@@ -141,6 +141,8 @@ export class ContainerComponent {
     component.addEventListener('mouseenter', e => this.showLabel(e, component));
     component.addEventListener('mouseleave', e => this.hideLabel(e, component));
     this.element.appendChild(component);
+    //capture state inside the container
+    Canvas.historyManager.captureState();
   }
   showLabel(event, component) {
     event.stopPropagation();

--- a/dist/index.js
+++ b/dist/index.js
@@ -12,6 +12,7 @@ import {
   syntaxHighlightHTML,
 } from './utils/utilityFunctions.js';
 import { createZipFile } from './utils/zipGenerator.js';
+import { ShortcutManager } from './services/ShortcutManager.js';
 document.addEventListener('DOMContentLoaded', () => {
   var _a, _b, _c, _d, _e, _f, _g, _h, _j;
   const canvas = new Canvas();
@@ -21,6 +22,8 @@ document.addEventListener('DOMContentLoaded', () => {
   createSidebar();
   Canvas.init();
   sidebar.init();
+  // Initialize ShortcutManager
+  ShortcutManager.init();
   CustomizationSidebar.init();
   const header = document.createElement('header');
   header.appendChild(createNavbar());

--- a/dist/services/ShortcutManager.d.ts
+++ b/dist/services/ShortcutManager.d.ts
@@ -1,0 +1,11 @@
+export declare class ShortcutManager {
+  /**
+   * Initializes keyboard shortcuts.
+   */
+  static init(): void;
+  /**
+   * Handles keydown events for shortcuts.
+   * @param event - The keyboard event.
+   */
+  private static handleKeydown;
+}

--- a/dist/services/ShortcutManager.js
+++ b/dist/services/ShortcutManager.js
@@ -1,0 +1,29 @@
+import { Canvas } from '../canvas/Canvas.js';
+export class ShortcutManager {
+  /**
+   * Initializes keyboard shortcuts.
+   */
+  static init() {
+    document.addEventListener('keydown', this.handleKeydown);
+  }
+  /**
+   * Handles keydown events for shortcuts.
+   * @param event - The keyboard event.
+   */
+  static handleKeydown(event) {
+    if (event.ctrlKey || event.metaKey) {
+      switch (event.key.toLowerCase()) {
+        case 'z': // Undo
+          event.preventDefault();
+          Canvas.historyManager.undo();
+          break;
+        case 'y': // Redo
+          event.preventDefault();
+          Canvas.historyManager.redo();
+          break;
+        default:
+          break;
+      }
+    }
+  }
+}

--- a/src/components/ContainerComponent.ts
+++ b/src/components/ContainerComponent.ts
@@ -166,6 +166,9 @@ export class ContainerComponent {
     component.addEventListener('mouseleave', e => this.hideLabel(e, component));
 
     this.element.appendChild(component);
+
+    //capture state inside the container
+    Canvas.historyManager.captureState();
   }
 
   private showLabel(event: MouseEvent, component: HTMLElement): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   syntaxHighlightHTML,
 } from './utils/utilityFunctions';
 import { createZipFile } from './utils/zipGenerator';
+import { ShortcutManager } from './services/ShortcutManager';
 
 document.addEventListener('DOMContentLoaded', () => {
   const canvas = new Canvas();
@@ -21,6 +22,8 @@ document.addEventListener('DOMContentLoaded', () => {
   createSidebar();
   Canvas.init();
   sidebar.init();
+  // Initialize ShortcutManager
+  ShortcutManager.init();
   CustomizationSidebar.init();
   const header = document.createElement('header');
   header.appendChild(createNavbar());

--- a/src/services/ShortcutManager.ts
+++ b/src/services/ShortcutManager.ts
@@ -1,0 +1,33 @@
+import { Canvas } from '../canvas/Canvas';
+
+export class ShortcutManager {
+  /**
+   * Initializes keyboard shortcuts.
+   */
+  static init() {
+    document.addEventListener('keydown', this.handleKeydown);
+  }
+
+  /**
+   * Handles keydown events for shortcuts.
+   * @param event - The keyboard event.
+   */
+  private static handleKeydown(event: KeyboardEvent) {
+    if (event.ctrlKey || event.metaKey) {
+      switch (event.key.toLowerCase()) {
+        case 'z': // Undo
+          event.preventDefault();
+          Canvas.historyManager.undo();
+          break;
+
+        case 'y': // Redo
+          event.preventDefault();
+          Canvas.historyManager.redo();
+          break;
+
+        default:
+          break;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Title

**feat: add new feature for controlling undo redo by shortcut keys**

---

## Description

### What does this PR do?

This PR introduces a new feature that allows users to control undo and redo actions using shortcut keys, enhancing the usability and efficiency of the canvas editor. Additionally, it includes fixes for managing states within containers to ensure a consistent and reliable editing experience.

### Related Issues


## Type of Change

- [x] 🐛 Bug fix
- [x] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.
- [x] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [x] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

_Provide screenshots or GIFs if this PR changes the UI or has visible results._

## Additional Context

_Include any other context, references, or information that may be useful for the reviewers._

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._
