### PR TITLE
fix: fix canvas getting empty with last step of undo

### DIFF
--- a/dist/canvas/Canvas.d.ts
+++ b/dist/canvas/Canvas.d.ts
@@ -1,4 +1,5 @@
 import { HistoryManager } from '../services/HistoryManager';
+import { JSONStorage } from '../services/JSONStorage';
 import { ComponentControlsManager } from './ComponentControls';
 export declare class Canvas {
   private static components;
@@ -6,7 +7,7 @@ export declare class Canvas {
   private static sidebarElement;
   static controlsManager: ComponentControlsManager;
   static historyManager: HistoryManager;
-  private static jsonStorage;
+  static jsonStorage: JSONStorage;
   static getComponents(): HTMLElement[];
   static setComponents(components: HTMLElement[]): void;
   private static componentFactory;

--- a/dist/services/HistoryManager.js
+++ b/dist/services/HistoryManager.js
@@ -42,8 +42,9 @@ export class HistoryManager {
     } else if (this.undoStack.length === 1) {
       const initialState = this.undoStack.pop();
       this.redoStack.push(initialState);
-      // Clear the canvas when no more undo states exist
-      Canvas.restoreState([]);
+      // Load existing layout from local storage and render, if any else empty the canvas
+      const savedState = Canvas.jsonStorage.load();
+      savedState ? Canvas.restoreState(savedState) : Canvas.restoreState([]);
     } else {
       console.warn('No more actions to undo.');
     }

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -19,7 +19,7 @@ export class Canvas {
   // Initialize CustomizationSidebar
 
   public static historyManager: HistoryManager; //accessible outside the Canvas class.
-  private static jsonStorage: JSONStorage;
+  public static jsonStorage: JSONStorage;
 
   // Add getters and setters for components to make it accessible outside the canvas class
   public static getComponents(): HTMLElement[] {

--- a/src/services/HistoryManager.ts
+++ b/src/services/HistoryManager.ts
@@ -53,8 +53,9 @@ export class HistoryManager {
       const initialState = this.undoStack.pop();
       this.redoStack.push(initialState);
 
-      // Clear the canvas when no more undo states exist
-      Canvas.restoreState([]);
+      // Load existing layout from local storage and render, if any else empty the canvas
+      const savedState = Canvas.jsonStorage.load();
+      savedState ? Canvas.restoreState(savedState) : Canvas.restoreState([]);
     } else {
       console.warn('No more actions to undo.');
     }


### PR DESCRIPTION
## Pull Request Title

**fix: fix canvas getting empty with last step of undo**

---

## Description

### What does this PR do?

This PR addresses the issue of the canvas becoming empty when performing the last step of the undo action. It restricts the undo functionality to retain the last saved page state, ensuring a consistent user experience and preventing accidental data loss.

### Related Issues

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.
- [x] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [x] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

_Provide screenshots or GIFs if this PR changes the UI or has visible results._

## Additional Context

_Include any other context, references, or information that may be useful for the reviewers._

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._
