### PR TITLE
Fix/grid manager

### DIFF
--- a/dist/canvas/Canvas.js
+++ b/dist/canvas/Canvas.js
@@ -62,6 +62,8 @@ export class Canvas {
     Canvas.canvasElement.innerHTML = '';
     Canvas.components = [];
     Canvas.historyManager.captureState(); // Capture cleared state for undo functionality if needed
+    // Reinitialize the drop-preview after clearing the canvas
+    Canvas.gridManager.initializeDropPreview(Canvas.canvasElement);
   }
   /**
    * Generates the current state of the canvas for undo/redo purposes.
@@ -209,6 +211,8 @@ export class Canvas {
         Canvas.components.push(component);
       }
     });
+    // Reinitialize the drop-preview after restoring the state
+    Canvas.gridManager.initializeDropPreview(Canvas.canvasElement);
   }
   static onDrop(event) {
     var _a;

--- a/dist/canvas/GridManager.d.ts
+++ b/dist/canvas/GridManager.d.ts
@@ -1,12 +1,45 @@
 export declare class GridManager {
   private cellSize;
+  /**
+   * Constructor for GridManager.
+   * @param cellSize - The size of each grid cell, default is 20px.
+   * Used to define the snapping behavior for grid-based alignment.
+   */
   constructor(cellSize?: number);
+  /**
+   * Initializes the drop-preview element for the canvas.
+   * Ensures there is only one drop-preview element at a time.
+   * Sets up drag-and-drop event listeners for positioning previews.
+   * Updates the visual grid alignment for drag-over operations.
+   * Called during initialization or restoration of the canvas.
+   */
   initializeDropPreview(canvasElement: HTMLElement): void;
+  /**
+   * Updates the position of the drop-preview to align with the grid.
+   * Calculates the nearest grid corner based on mouse position.
+   * Ensures the drop-preview element reflects the correct alignment.
+   * Enhances drag-and-drop UX by snapping the preview to the grid.
+   * Called on every drag-over event over the canvas element.
+   */
   showGridCornerHighlight(
     event: DragEvent,
     dropPreview: HTMLElement,
     canvasElement: HTMLElement
   ): void;
+  /**
+   * Calculates the nearest grid corner position based on mouse coordinates.
+   * Determines the mouse position relative to the canvas element.
+   * Snaps the mouse position to the closest grid corner for alignment.
+   * Supports grid-based snapping behavior during drag-and-drop.
+   * Returns an object containing the grid-aligned X and Y coordinates.
+   */
   mousePositionAtGridCorner(event: DragEvent, canvasElement: HTMLElement): any;
+  /**
+   * Retrieves the size of each grid cell.
+   * Provides a way to access the configured grid size for alignment.
+   * Useful for other components needing grid cell dimensions.
+   * Returns the current cell size set during initialization.
+   * The default value is 20px unless overridden in the constructor.
+   */
   getCellSize(): number;
 }

--- a/dist/canvas/GridManager.js
+++ b/dist/canvas/GridManager.js
@@ -1,55 +1,77 @@
 export class GridManager {
+  /**
+   * Constructor for GridManager.
+   * @param cellSize - The size of each grid cell, default is 20px.
+   * Used to define the snapping behavior for grid-based alignment.
+   */
   constructor(cellSize = 20) {
     this.cellSize = cellSize;
   }
-  /*
-   * Initializes the "drop-preview" element for the canvas.
-   * Ensures drag-and-drop functionality works correctly after canvas is restored.
+  /**
+   * Initializes the drop-preview element for the canvas.
+   * Ensures there is only one drop-preview element at a time.
+   * Sets up drag-and-drop event listeners for positioning previews.
+   * Updates the visual grid alignment for drag-over operations.
+   * Called during initialization or restoration of the canvas.
    */
   initializeDropPreview(canvasElement) {
-    // Remove existing drop-preview if present
     const existingDropPreview = canvasElement.querySelector('.drop-preview');
     if (existingDropPreview) {
       existingDropPreview.remove();
     }
-    // Create and append a new drop-preview element
     const dropPreview = document.createElement('div');
     dropPreview.className = 'drop-preview';
     canvasElement.appendChild(dropPreview);
-    // Attach dragover event to show grid corner highlight
     canvasElement.addEventListener('dragover', event => {
       event.preventDefault();
       this.showGridCornerHighlight(event, dropPreview, canvasElement);
     });
-    // Attach dragleave event to hide the preview
     canvasElement.addEventListener('dragleave', () => {
-      dropPreview.classList.remove('visible'); // Hide preview on drag leave
+      dropPreview.classList.remove('visible');
     });
   }
+  /**
+   * Updates the position of the drop-preview to align with the grid.
+   * Calculates the nearest grid corner based on mouse position.
+   * Ensures the drop-preview element reflects the correct alignment.
+   * Enhances drag-and-drop UX by snapping the preview to the grid.
+   * Called on every drag-over event over the canvas element.
+   */
   showGridCornerHighlight(event, dropPreview, canvasElement) {
     const gridCellSize = 20;
     const { gridX, gridY } = this.mousePositionAtGridCorner(
       event,
       canvasElement
     );
-    // Update preview position and visibility
     dropPreview.style.left = `${gridX}px`;
     dropPreview.style.top = `${gridY}px`;
     dropPreview.style.width = `${gridCellSize}px`;
     dropPreview.style.height = `${gridCellSize}px`;
     dropPreview.classList.add('visible');
   }
+  /**
+   * Calculates the nearest grid corner position based on mouse coordinates.
+   * Determines the mouse position relative to the canvas element.
+   * Snaps the mouse position to the closest grid corner for alignment.
+   * Supports grid-based snapping behavior during drag-and-drop.
+   * Returns an object containing the grid-aligned X and Y coordinates.
+   */
   mousePositionAtGridCorner(event, canvasElement) {
-    const gridCellSize = 20; // Size of each grid cell
+    const gridCellSize = 20;
     const canvasRect = canvasElement.getBoundingClientRect();
-    // Calculate mouse position relative to canvas
     const mouseX = event.clientX - canvasRect.left;
     const mouseY = event.clientY - canvasRect.top;
-    // Snap mouse position to the nearest grid corner
     const gridX = Math.floor(mouseX / gridCellSize) * gridCellSize;
     const gridY = Math.floor(mouseY / gridCellSize) * gridCellSize;
     return { gridX, gridY };
   }
+  /**
+   * Retrieves the size of each grid cell.
+   * Provides a way to access the configured grid size for alignment.
+   * Useful for other components needing grid cell dimensions.
+   * Returns the current cell size set during initialization.
+   * The default value is 20px unless overridden in the constructor.
+   */
   getCellSize() {
     return this.cellSize;
   }

--- a/dist/components/TwoColumnComponent.js
+++ b/dist/components/TwoColumnComponent.js
@@ -1,4 +1,4 @@
-import { Canvas } from '../canvas/Canvas.js.';
+import { Canvas } from '../canvas/Canvas.js..js.js.js.js.js.js';
 export class TwoColumnComponent {
   constructor() {
     this.element = document.createElement('div');

--- a/dist/components/TwoColumnComponent.js
+++ b/dist/components/TwoColumnComponent.js
@@ -1,4 +1,4 @@
-import { Canvas } from '../canvas/Canvas.js..js.js.js.js.js.js';
+import { Canvas } from '../canvas/Canvas.js..js.js.js.js.js.js.js.js.js.js.js';
 export class TwoColumnComponent {
   constructor() {
     this.element = document.createElement('div');

--- a/dist/services/HTMLGenerator.js
+++ b/dist/services/HTMLGenerator.js
@@ -48,6 +48,7 @@ export class HTMLGenerator {
       'resizer',
       'upload-btn',
       'component-resizer',
+      'drop-preview',
     ];
     Array.from(element.children).forEach(child => {
       const childElement = child;
@@ -64,7 +65,7 @@ export class HTMLGenerator {
       inputElements.forEach(input => input.remove());
       // Remove specific child elements
       const elementsToRemove = childElement.querySelectorAll(
-        '.component-controls, .delete-icon, .component-label,.column-label, .resizers, .resizer, .upload-btn, component-resizer'
+        '.component-controls, .delete-icon, .component-label,.column-label, .resizers, .resizer, .drop-preview, .upload-btn, component-resizer'
       );
       elementsToRemove.forEach(el => el.remove());
       // Recursively clean up nested elements

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -92,6 +92,9 @@ export class Canvas {
     Canvas.canvasElement.innerHTML = '';
     Canvas.components = [];
     Canvas.historyManager.captureState(); // Capture cleared state for undo functionality if needed
+
+    // Reinitialize the drop-preview after clearing the canvas
+    Canvas.gridManager.initializeDropPreview(Canvas.canvasElement);
   }
 
   /**
@@ -254,6 +257,8 @@ export class Canvas {
         Canvas.components.push(component);
       }
     });
+    // Reinitialize the drop-preview after restoring the state
+    Canvas.gridManager.initializeDropPreview(Canvas.canvasElement);
   }
 
   static onDrop(event: DragEvent) {

--- a/src/canvas/GridManager.ts
+++ b/src/canvas/GridManager.ts
@@ -1,37 +1,49 @@
 export class GridManager {
   private cellSize: number;
 
+  /**
+   * Constructor for GridManager.
+   * @param cellSize - The size of each grid cell, default is 20px.
+   * Used to define the snapping behavior for grid-based alignment.
+   */
   constructor(cellSize: number = 20) {
     this.cellSize = cellSize;
   }
-  /*
-   * Initializes the "drop-preview" element for the canvas.
-   * Ensures drag-and-drop functionality works correctly after canvas is restored.
+
+  /**
+   * Initializes the drop-preview element for the canvas.
+   * Ensures there is only one drop-preview element at a time.
+   * Sets up drag-and-drop event listeners for positioning previews.
+   * Updates the visual grid alignment for drag-over operations.
+   * Called during initialization or restoration of the canvas.
    */
   initializeDropPreview(canvasElement: HTMLElement) {
-    // Remove existing drop-preview if present
     const existingDropPreview = canvasElement.querySelector('.drop-preview');
     if (existingDropPreview) {
       existingDropPreview.remove();
     }
 
-    // Create and append a new drop-preview element
     const dropPreview = document.createElement('div');
     dropPreview.className = 'drop-preview';
     canvasElement.appendChild(dropPreview);
 
-    // Attach dragover event to show grid corner highlight
     canvasElement.addEventListener('dragover', event => {
       event.preventDefault();
       this.showGridCornerHighlight(event, dropPreview, canvasElement);
     });
 
-    // Attach dragleave event to hide the preview
     canvasElement.addEventListener('dragleave', () => {
-      dropPreview.classList.remove('visible'); // Hide preview on drag leave
+      dropPreview.classList.remove('visible');
     });
   }
 
+  /**
+   * Updates the position of the drop-preview to align with the grid.
+   * Calculates the nearest grid corner based on mouse position.
+   * Ensures the drop-preview element reflects the correct alignment.
+   * Enhances drag-and-drop UX by snapping the preview to the grid.
+   * Called on every drag-over event over the canvas element.
+   */
   showGridCornerHighlight(
     event: DragEvent,
     dropPreview: HTMLElement,
@@ -43,7 +55,6 @@ export class GridManager {
       canvasElement
     );
 
-    // Update preview position and visibility
     dropPreview.style.left = `${gridX}px`;
     dropPreview.style.top = `${gridY}px`;
     dropPreview.style.width = `${gridCellSize}px`;
@@ -51,21 +62,33 @@ export class GridManager {
     dropPreview.classList.add('visible');
   }
 
+  /**
+   * Calculates the nearest grid corner position based on mouse coordinates.
+   * Determines the mouse position relative to the canvas element.
+   * Snaps the mouse position to the closest grid corner for alignment.
+   * Supports grid-based snapping behavior during drag-and-drop.
+   * Returns an object containing the grid-aligned X and Y coordinates.
+   */
   mousePositionAtGridCorner(event: DragEvent, canvasElement: HTMLElement): any {
-    const gridCellSize = 20; // Size of each grid cell
+    const gridCellSize = 20;
     const canvasRect = canvasElement.getBoundingClientRect();
 
-    // Calculate mouse position relative to canvas
     const mouseX = event.clientX - canvasRect.left;
     const mouseY = event.clientY - canvasRect.top;
 
-    // Snap mouse position to the nearest grid corner
     const gridX = Math.floor(mouseX / gridCellSize) * gridCellSize;
     const gridY = Math.floor(mouseY / gridCellSize) * gridCellSize;
 
     return { gridX, gridY };
   }
 
+  /**
+   * Retrieves the size of each grid cell.
+   * Provides a way to access the configured grid size for alignment.
+   * Useful for other components needing grid cell dimensions.
+   * Returns the current cell size set during initialization.
+   * The default value is 20px unless overridden in the constructor.
+   */
   getCellSize(): number {
     return this.cellSize;
   }

--- a/src/services/HTMLGenerator.ts
+++ b/src/services/HTMLGenerator.ts
@@ -59,6 +59,7 @@ export class HTMLGenerator {
       'resizer',
       'upload-btn',
       'component-resizer',
+      'drop-preview',
     ];
 
     Array.from(element.children).forEach(child => {
@@ -80,7 +81,7 @@ export class HTMLGenerator {
 
       // Remove specific child elements
       const elementsToRemove = childElement.querySelectorAll(
-        '.component-controls, .delete-icon, .component-label,.column-label, .resizers, .resizer, .upload-btn, component-resizer'
+        '.component-controls, .delete-icon, .component-label,.column-label, .resizers, .resizer, .drop-preview, .upload-btn, component-resizer'
       );
       elementsToRemove.forEach(el => el.remove());
 


### PR DESCRIPTION
### Combined Commit: Fix Grid Highlighter and Drop Preview Issues

#### Description

Remove the grid highlighter in the view page for a cleaner UI and re-apply the drop preview functionality after restoration and canvas reset to ensure consistent behavior.

---

## Description

### What does this PR do?

- Removes the grid highlighter in the view page.
  - Ensures the UI remains clean and user-friendly during viewing.
- Re-applies the drop preview functionality.
  - Handles scenarios involving restoration and canvas reset.
  - Improves usability and maintains expected behaviors.

### Related Issues

- Refs: []

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.
- [x] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [x] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

_Provide screenshots or GIFs if this PR changes the UI or has visible results._

## Additional Context

_Include any other context, references, or information that may be useful for the reviewers._

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._
