### PR TITLE
fix: fix appearance of extra delete button on column

### DIFF
--- a/dist/components/TextComponent.js
+++ b/dist/components/TextComponent.js
@@ -3,7 +3,7 @@ export class TextComponent {
     this.text = text; // Default text value
   }
   create() {
-    const element = document.createElement('p');
+    const element = document.createElement('div');
     element.innerText = this.text; // Use dynamic text passed in constructor
     element.contentEditable = 'true'; // Enable inline editing
     element.classList.add('text-component');

--- a/dist/components/TwoColumnComponent.js
+++ b/dist/components/TwoColumnComponent.js
@@ -1,4 +1,4 @@
-import { Canvas } from '../canvas/Canvas.js.js.js';
+import { Canvas } from '../canvas/Canvas.js.js.js.js.js.js';
 export class TwoColumnComponent {
   constructor() {
     this.element = document.createElement('div');

--- a/src/components/TextComponent.ts
+++ b/src/components/TextComponent.ts
@@ -6,7 +6,7 @@ export class TextComponent {
   }
 
   create(): HTMLElement {
-    const element = document.createElement('p');
+    const element = document.createElement('div');
     element.innerText = this.text; // Use dynamic text passed in constructor
     element.contentEditable = 'true'; // Enable inline editing
     element.classList.add('text-component');


### PR DESCRIPTION


### Fix extra delete icon on the immediate parent column

#### Description

Fix the issue where double delete icons are displayed in 2 and 3-column containers after inserting a text component.

---

## Description

### What does this PR do?

- Resolves the issue of double delete icons appearing in 2 and 3-column containers.
  - Occurs after adding a text component.
  - Ensures only one delete icon is shown per container for clarity.

### Related Issues

- Refs: []

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.
- [x] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [x] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

_Provide screenshots or GIFs if this PR changes the UI or has visible results._

## Additional Context

_Include any other context, references, or information that may be useful for the reviewers._

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._
